### PR TITLE
Accept any iterable in Data, not just arrays. Plus code cleanup and PHP dependency bumped to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "description": "Plugin for Sylius to make customizable reports.",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.4",
 
         "sylius/sylius": "~1.8.0 || ~1.9.0",
         "beberlei/doctrineextensions": "^1.2"

--- a/spec/DataFetcher/DataSpec.php
+++ b/spec/DataFetcher/DataSpec.php
@@ -17,7 +17,7 @@ class DataSpec extends ObjectBehavior
 
     function its_labels_is_mutable(): void
     {
-        $this->getLabels()->shouldReturn(null);
+        $this->getLabels()->shouldReturn([]);
 
         $this->setLabels(['labelA', 'labelB']);
         $this->getLabels()->shouldReturn(['labelA', 'labelB']);
@@ -25,7 +25,7 @@ class DataSpec extends ObjectBehavior
 
     function its_data_is_mutable(): void
     {
-        $this->getData()->shouldReturn(null);
+        $this->getData()->shouldReturn([]);
 
         $this->setData(['14', '10']);
         $this->getData()->shouldReturn(['14', '10']);

--- a/spec/DataFetcher/DelegatingDataFetcherSpec.php
+++ b/spec/DataFetcher/DelegatingDataFetcherSpec.php
@@ -39,17 +39,6 @@ class DelegatingDataFetcherSpec extends ObjectBehavior
         $this->getDataFetcher($report)->shouldReturn($userRegistrationDataFetcher);
     }
 
-    function it_throws_an_exception_if_report_has_not_data_fetcher(ReportInterface $report, ServiceRegistryInterface $registry)
-    {
-        $report->getDataFetcher()->willReturn(null);
-        $registry->get(DefaultDataFetchers::USER_REGISTRATION)->willReturn(UserRegistrationDataFetcher::class);
-
-        $this
-            ->shouldThrow(new \InvalidArgumentException('Cannot fetch data for ReportInterface instance without DataFetcher defined.'))
-            ->during('getDataFetcher', [$report])
-        ;
-    }
-
     function it_fetch_the_data_with_given_report_configuration(ReportInterface $report, DataFetcherInterface $dataFetcher, ServiceRegistryInterface $registry)
     {
         $reportConfiguration = [

--- a/spec/Renderer/ChartRendererSpec.php
+++ b/spec/Renderer/ChartRendererSpec.php
@@ -9,6 +9,7 @@ use Odiseo\SyliusReportPlugin\Renderer\ChartRenderer;
 use Odiseo\SyliusReportPlugin\Renderer\RendererInterface;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -17,7 +18,7 @@ use Symfony\Component\Templating\EngineInterface;
  */
 final class ChartRendererSpec extends ObjectBehavior
 {
-    function let(EngineInterface $templating)
+    function let(Environment $templating)
     {
         $this->beConstructedWith($templating);
     }

--- a/spec/Renderer/DelegatingRendererSpec.php
+++ b/spec/Renderer/DelegatingRendererSpec.php
@@ -32,22 +32,11 @@ class DelegatingRendererSpec extends ObjectBehavior
         $this->shouldImplement(DelegatingRendererInterface::class);
     }
 
-    function it_get_the_renderer_with_given_report(ReportInterface $report, ServiceRegistryInterface $registry)
+    function it_get_the_renderer_with_given_report(ReportInterface $report, ServiceRegistryInterface $registry, TableRenderer $tableRenderer)
     {
         $report->getRenderer()->willReturn(DefaultRenderers::TABLE);
-        $registry->get(DefaultRenderers::TABLE)->willReturn(TableRenderer::class);
-        $this->getRenderer($report)->shouldReturn(TableRenderer::class);
-    }
-
-    function it_throws_an_exception_if_report_has_not_renderer(ReportInterface $report, ServiceRegistryInterface $registry)
-    {
-        $report->getRenderer()->willReturn(null);
-        $registry->get(DefaultRenderers::TABLE)->willReturn(TableRenderer::class);
-
-        $this
-            ->shouldThrow(new \InvalidArgumentException('Cannot render data for ReportInterface instance without renderer defined.'))
-            ->during('getRenderer', [$report])
-        ;
+        $registry->get(DefaultRenderers::TABLE)->willReturn($tableRenderer);
+        $this->getRenderer($report)->shouldReturn($tableRenderer);
     }
 
     function it_render_with_given_report_configuration_and_data(ReportInterface $report, RendererInterface $renderer, Data $data, ServiceRegistryInterface $registry)

--- a/spec/Renderer/TableRendererSpec.php
+++ b/spec/Renderer/TableRendererSpec.php
@@ -9,6 +9,7 @@ use Odiseo\SyliusReportPlugin\Renderer\RendererInterface;
 use Odiseo\SyliusReportPlugin\Renderer\TableRenderer;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -17,7 +18,7 @@ use Symfony\Component\Templating\EngineInterface;
  */
 final class TableRendererSpec extends ObjectBehavior
 {
-    function let(EngineInterface $templating)
+    function let(Environment $templating)
     {
         $this->beConstructedWith($templating);
     }
@@ -56,7 +57,7 @@ final class TableRendererSpec extends ObjectBehavior
     function it_renders_a_no_data_with_given_configuration(ReportInterface $report, Data $reportData, EngineInterface $templating)
     {
         $reportData->getLabels()->willReturn(['month', 'user_total']);
-        $reportData->getData()->willReturn(null);
+        $reportData->getData()->willReturn([]);
 
         $report->getRendererConfiguration()->willReturn(['template' => '@OdiseoSyliusReportPlugin/noDataTemplate.html.twig']);
 

--- a/src/Controller/Action/CitySearchAction.php
+++ b/src/Controller/Action/CitySearchAction.php
@@ -18,14 +18,11 @@ use Symfony\Component\HttpFoundation\Response;
  */
 final class CitySearchAction
 {
-    /** @var AddressRepositoryInterface */
-    private $addressRepository;
+    private AddressRepositoryInterface $addressRepository;
 
-    /** @var RepositoryInterface */
-    private $countryRepository;
+    private RepositoryInterface $countryRepository;
 
-    /** @var ConfigurableViewHandlerInterface */
-    private $viewHandler;
+    private ConfigurableViewHandlerInterface $viewHandler;
 
     public function __construct(
         AddressRepositoryInterface $addressRepository,
@@ -37,11 +34,6 @@ final class CitySearchAction
         $this->viewHandler = $viewHandler;
     }
 
-    /**
-     * @param Request $request
-     *
-     * @return Response
-     */
     public function __invoke(Request $request): Response
     {
         $addresses = $this->getAddresses($request->get('city', ''));
@@ -53,11 +45,6 @@ final class CitySearchAction
         return $this->viewHandler->handle($view);
     }
 
-    /**
-     * @param string $query
-     *
-     * @return array
-     */
     private function getAddresses(string $query): array
     {
         $addresses = [];
@@ -65,15 +52,15 @@ final class CitySearchAction
 
         /** @var AddressInterface $address */
         foreach ($searchAddresses as $address) {
-            /** @var CountryInterface $country */
+            /** @var CountryInterface|null $country */
             $country = $this->countryRepository->findOneBy([
                 'code' => $address->getCountryCode()
             ]);
 
             $countryName = $country !== null ? $country->getName() : $address->getCountryCode();
 
-            $cityLabel = ucfirst(strtolower($address->getCity())).', '.$countryName;
-            $isNew = count(array_filter($addresses, function ($address) use ($cityLabel) {
+            $cityLabel = ucfirst(strtolower($address->getCity() ?? '')).', '.$countryName;
+            $isNew = count(array_filter($addresses, function ($address) use ($cityLabel): bool {
                 return $address['city'] === $cityLabel;
             })) === 0;
 

--- a/src/Controller/Action/PostcodeSearchAction.php
+++ b/src/Controller/Action/PostcodeSearchAction.php
@@ -18,14 +18,11 @@ use Symfony\Component\HttpFoundation\Response;
  */
 final class PostcodeSearchAction
 {
-    /** @var AddressRepositoryInterface */
-    private $addressRepository;
+    private AddressRepositoryInterface $addressRepository;
 
-    /** @var RepositoryInterface */
-    private $countryRepository;
+    private RepositoryInterface $countryRepository;
 
-    /** @var ConfigurableViewHandlerInterface */
-    private $viewHandler;
+    private ConfigurableViewHandlerInterface $viewHandler;
 
     public function __construct(
         AddressRepositoryInterface $addressRepository,
@@ -37,11 +34,6 @@ final class PostcodeSearchAction
         $this->viewHandler = $viewHandler;
     }
 
-    /**
-     * @param Request $request
-     *
-     * @return Response
-     */
     public function __invoke(Request $request): Response
     {
         $addresses = $this->getAddresses($request->get('postcode', ''));
@@ -53,11 +45,6 @@ final class PostcodeSearchAction
         return $this->viewHandler->handle($view);
     }
 
-    /**
-     * @param string $query
-     *
-     * @return array
-     */
     private function getAddresses(string $query): array
     {
         $addresses = [];
@@ -65,7 +52,7 @@ final class PostcodeSearchAction
 
         /** @var AddressInterface $address */
         foreach ($searchAddresses as $address) {
-            /** @var CountryInterface $country */
+            /** @var CountryInterface|null $country */
             $country = $this->countryRepository->findOneBy([
                 'code' => $address->getCountryCode()
             ]);
@@ -73,7 +60,7 @@ final class PostcodeSearchAction
             $countryName = $country !== null ? $country->getName() : $address->getCountryCode();
 
             $postcodeLabel = $address->getPostcode().', '.$countryName;
-            $isNew = count(array_filter($addresses, function ($address) use ($postcodeLabel) {
+            $isNew = count(array_filter($addresses, function ($address) use ($postcodeLabel): bool {
                 return $address['postcode'] === $postcodeLabel;
             })) === 0;
 

--- a/src/Controller/Action/ProductSearchAction.php
+++ b/src/Controller/Action/ProductSearchAction.php
@@ -17,14 +17,11 @@ use Symfony\Component\HttpFoundation\Response;
  */
 final class ProductSearchAction
 {
-    /** @var ProductRepositoryInterface */
-    private $productRepository;
+    private ProductRepositoryInterface$productRepository;
 
-    /** @var LocaleContextInterface */
-    private $localeContext;
+    private LocaleContextInterface $localeContext;
 
-    /** @var ConfigurableViewHandlerInterface */
-    private $viewHandler;
+    private ConfigurableViewHandlerInterface $viewHandler;
 
     public function __construct(
         ProductRepositoryInterface $productRepository,
@@ -36,11 +33,6 @@ final class ProductSearchAction
         $this->viewHandler = $viewHandler;
     }
 
-    /**
-     * @param Request $request
-     *
-     * @return Response
-     */
     public function __invoke(Request $request): Response
     {
         $locale = $this->localeContext->getLocaleCode();
@@ -54,12 +46,6 @@ final class ProductSearchAction
         return $this->viewHandler->handle($view);
     }
 
-    /**
-     * @param string $query
-     * @param string $locale
-     *
-     * @return array
-     */
     private function getProducts(string $query, string $locale): array
     {
         $products = [];
@@ -67,8 +53,8 @@ final class ProductSearchAction
 
         /** @var ProductInterface $product */
         foreach ($searchProducts as $product) {
-            $productLabel = ucfirst(strtolower($product->getName()));
-            $isNew = count(array_filter($products, function ($product) use ($productLabel) {
+            $productLabel = ucfirst(strtolower($product->getName() ?? ''));
+            $isNew = count(array_filter($products, function ($product) use ($productLabel): bool {
                 return $product['name'] === $productLabel;
             })) === 0;
 

--- a/src/Controller/Action/ProvinceSearchAction.php
+++ b/src/Controller/Action/ProvinceSearchAction.php
@@ -19,17 +19,13 @@ use Symfony\Component\HttpFoundation\Response;
  */
 final class ProvinceSearchAction
 {
-    /** @var AddressRepositoryInterface */
-    private $addressRepository;
+    private AddressRepositoryInterface $addressRepository;
 
-    /** @var RepositoryInterface */
-    private $provinceRepository;
+    private RepositoryInterface $provinceRepository;
 
-    /** @var RepositoryInterface */
-    private $countryRepository;
+    private RepositoryInterface $countryRepository;
 
-    /** @var ConfigurableViewHandlerInterface */
-    private $viewHandler;
+    private ConfigurableViewHandlerInterface $viewHandler;
 
     public function __construct(
         AddressRepositoryInterface $addressRepository,
@@ -43,11 +39,6 @@ final class ProvinceSearchAction
         $this->viewHandler = $viewHandler;
     }
 
-    /**
-     * @param Request $request
-     *
-     * @return Response
-     */
     public function __invoke(Request $request): Response
     {
         $addresses = $this->getAddresses($request->get('province', ''));
@@ -59,11 +50,6 @@ final class ProvinceSearchAction
         return $this->viewHandler->handle($view);
     }
 
-    /**
-     * @param string $query
-     *
-     * @return array
-     */
     private function getAddresses(string $query): array
     {
         $addresses = [];
@@ -71,7 +57,7 @@ final class ProvinceSearchAction
 
         /** @var AddressInterface $address */
         foreach ($searchAddresses as $address) {
-            /** @var CountryInterface $country */
+            /** @var CountryInterface|null $country */
             $country = $this->countryRepository->findOneBy([
                 'code' => $address->getCountryCode()
             ]);
@@ -79,8 +65,8 @@ final class ProvinceSearchAction
             $countryName = $country !== null ? $country->getName() : $address->getCountryCode();
 
             $provinceName = $this->getProvinceName($address);
-            $provinceLabel = ucfirst(strtolower($provinceName)).', '.$countryName;
-            $isNew = count(array_filter($addresses, function ($address) use ($provinceLabel) {
+            $provinceLabel = ucfirst(strtolower($provinceName ?? '')).', '.$countryName;
+            $isNew = count(array_filter($addresses, function ($address) use ($provinceLabel): bool {
                 return $address['province'] === $provinceLabel;
             })) === 0;
 
@@ -95,11 +81,6 @@ final class ProvinceSearchAction
         return $addresses;
     }
 
-    /**
-     * @param AddressInterface $address
-     *
-     * @return string|null
-     */
     private function getProvinceName(AddressInterface $address): ?string
     {
         $provinceName = $address->getProvinceName();

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Controller;
 
 use Odiseo\SyliusReportPlugin\DataFetcher\Data;
@@ -24,12 +26,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ReportController extends ResourceController
 {
-    /**
-     * @param Request $request
-     *
-     * @return Response
-     */
-    public function renderAction(Request $request)
+    public function renderAction(Request $request): Response
     {
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
 
@@ -55,12 +52,7 @@ class ReportController extends ResourceController
         return $this->createRestView($configuration, $report);
     }
 
-    /**
-     * @param Request $request
-     *
-     * @return Response
-     */
-    public function exportAction(Request $request)
+    public function exportAction(Request $request): Response
     {
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
 
@@ -93,23 +85,14 @@ class ReportController extends ResourceController
         return $response;
     }
 
-    /**
-     * @param ReportInterface $report
-     * @param array $dataFetcherConfiguration
-     *
-     * @return Response
-     */
-    public function embedAction(ReportInterface $report, array $dataFetcherConfiguration = [])
+    public function embedAction(ReportInterface $report, array $dataFetcherConfiguration = []): Response
     {
         $data = $this->getReportDataFetcher()->fetch($report, $dataFetcherConfiguration);
 
         return new Response($this->getReportRenderer()->render($report, $data));
     }
 
-    /**
-     * @return DelegatingRendererInterface
-     */
-    private function getReportRenderer()
+    private function getReportRenderer(): DelegatingRendererInterface
     {
         /** @var DelegatingRendererInterface $renderer */
         $renderer = $this->container->get('odiseo_sylius_report.renderer');
@@ -117,10 +100,7 @@ class ReportController extends ResourceController
         return $renderer;
     }
 
-    /**
-     * @return DelegatingDataFetcherInterface
-     */
-    private function getReportDataFetcher()
+    private function getReportDataFetcher(): DelegatingDataFetcherInterface
     {
         /** @var DelegatingDataFetcherInterface $dataFetcher */
         $dataFetcher = $this->container->get('odiseo_sylius_report.data_fetcher');
@@ -128,13 +108,7 @@ class ReportController extends ResourceController
         return $dataFetcher;
     }
 
-    /**
-     * @param string $filename
-     * @param Data $data
-     *
-     * @return Response
-     */
-    protected function createJsonResponse($filename, $data)
+    protected function createJsonResponse(string $filename, Data $data): Response
     {
         $responseData = [];
         foreach ($data->getData() as $key => $value) {
@@ -152,29 +126,14 @@ class ReportController extends ResourceController
         return $response;
     }
 
-    /**
-     * @param string $filename
-     * @param Data $data
-     *
-     * @return Response
-     */
-    protected function createCsvResponse($filename, $data)
+    protected function createCsvResponse(string $filename, Data $data): Response
     {
-        $labels = [$data->getLabels()];
-
-        $responseData = array_merge($labels, $data->getData());
-
-        $response = new CsvResponse($responseData);
+        $response = new CsvResponse($data);
         $response->setFilename($filename.'.csv');
 
         return $response;
     }
 
-    /**
-     * @param ReportInterface $report
-     * @param Request $request
-     * @return FormInterface
-     */
     protected function getReportDataFetcherConfigurationForm(ReportInterface $report, Request $request): FormInterface
     {
         /** @var FormFactoryInterface $formFactory */
@@ -190,12 +149,7 @@ class ReportController extends ResourceController
         return $configurationForm;
     }
 
-    /**
-     * @param string $string
-     *
-     * @return string
-     */
-    private function slugify($string)
+    private function slugify(string $string): string
     {
         return strtolower(trim(preg_replace('/[^A-Za-z0-9-]+/', '-', $string)));
     }

--- a/src/DataFetcher/BaseDataFetcher.php
+++ b/src/DataFetcher/BaseDataFetcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DataFetcher;
 
 use Odiseo\SyliusReportPlugin\Filter\QueryFilterInterface;
@@ -9,14 +11,8 @@ use Odiseo\SyliusReportPlugin\Filter\QueryFilterInterface;
  */
 abstract class BaseDataFetcher implements DataFetcherInterface
 {
-    /**
-     * @var QueryFilterInterface
-     */
-    protected $queryFilter;
+    protected QueryFilterInterface $queryFilter;
 
-    /**
-     * @param QueryFilterInterface $queryFilter
-     */
     public function __construct(QueryFilterInterface $queryFilter)
     {
         $this->queryFilter = $queryFilter;
@@ -24,18 +20,12 @@ abstract class BaseDataFetcher implements DataFetcherInterface
 
     /**
      * Responsible for setup and add filters to the base QueryFilter's Query builder
-     *
-     * @param array $configuration
      */
     abstract protected function setupQueryFilter(array $configuration = []): void;
 
     /**
      * Responsible for providing raw data to fetch, from the configuration (ie: start date, end date, time period,
      * empty records flag, interval, period format, presentation format, group by).
-     *
-     * @param array $configuration
-     *
-     * @return array
      */
     protected function getData(array $configuration = []): array
     {

--- a/src/DataFetcher/Data.php
+++ b/src/DataFetcher/Data.php
@@ -1,68 +1,37 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DataFetcher;
 
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 class Data
 {
-    /**
-     * array of labels
-     *
-     * @var array
-     */
-    private $labels;
+    private iterable $labels = [];
 
-    /**
-     * array of data
-     *
-     * @var array
-     */
-    private $data;
+    private iterable $data = [];
 
-    /**
-     * Gets the array of labels.
-     *
-     * @return array
-     */
-    public function getLabels()
+    public function getLabels(): iterable
     {
         return $this->labels;
     }
 
-    /**
-     * Sets the array of labels.
-     *
-     * @param array $labels the labels
-     *
-     * @return self
-     */
-    public function setLabels(array $labels)
+    public function setLabels(iterable $labels): self
     {
         $this->labels = $labels;
 
         return $this;
     }
 
-    /**
-     * Gets the array of data.
-     *
-     * @return array
-     */
-    public function getData()
+    public function getData(): iterable
     {
         return $this->data;
     }
 
-    /**
-     * Sets the array of data.
-     *
-     * @param array $data the data
-     *
-     * @return self
-     */
-    public function setData(array $data)
+    public function setData(iterable $data): self
     {
         $this->data = $data;
 

--- a/src/DataFetcher/DataFetcherInterface.php
+++ b/src/DataFetcher/DataFetcherInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DataFetcher;
 
 /**

--- a/src/DataFetcher/DefaultDataFetchers.php
+++ b/src/DataFetcher/DefaultDataFetchers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DataFetcher;
 
 /**

--- a/src/DataFetcher/DelegatingDataFetcher.php
+++ b/src/DataFetcher/DelegatingDataFetcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DataFetcher;
 
 use InvalidArgumentException;
@@ -16,43 +18,26 @@ class DelegatingDataFetcher implements DelegatingDataFetcherInterface
 {
     /**
      * DataFetcher registry.
-     *
-     * @var ServiceRegistryInterface
      */
-    protected $registry;
+    protected ServiceRegistryInterface $registry;
 
-    /**
-     * @param ServiceRegistryInterface $registry
-     */
     public function __construct(ServiceRegistryInterface $registry)
     {
         $this->registry = $registry;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function fetch(ReportInterface $report, array $configuration = []): Data
     {
         $dataFetcher = $this->getDataFetcher($report);
-        $configuration = empty($configuration) ? $report->getDataFetcherConfiguration() : $configuration;
+        $configuration = [] === $configuration ? $report->getDataFetcherConfiguration() : $configuration;
 
         return $dataFetcher->fetch($configuration);
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws InvalidArgumentException If the report does not have a data fetcher.
-     */
     public function getDataFetcher(ReportInterface $report): DataFetcherInterface
     {
-        if (null === $type = $report->getDataFetcher()) {
-            throw new InvalidArgumentException('Cannot fetch data for ReportInterface instance without DataFetcher defined.');
-        }
-
         /** @var DataFetcherInterface $dataFetcher */
-        $dataFetcher = $this->registry->get($type);
+        $dataFetcher = $this->registry->get($report->getDataFetcher());
 
         return $dataFetcher;
     }

--- a/src/DataFetcher/DelegatingDataFetcherInterface.php
+++ b/src/DataFetcher/DelegatingDataFetcherInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DataFetcher;
 
 use Odiseo\SyliusReportPlugin\Model\ReportInterface;
@@ -14,20 +16,11 @@ interface DelegatingDataFetcherInterface
 {
     /**
      * Fetch data for given config.
-     *
-     * @param ReportInterface $report
-     * @param array           $configuration
-     *
-     * @return Data
      */
     public function fetch(ReportInterface $report, array $configuration = []): Data;
 
     /**
      * Return the DataFetcherInterface of the ReportInterface given
-     *
-     * @param ReportInterface $report
-     *
-     * @return DataFetcherInterface
      */
     public function getDataFetcher(ReportInterface $report): DataFetcherInterface;
 }

--- a/src/DataFetcher/NumberOfOrdersDataFetcher.php
+++ b/src/DataFetcher/NumberOfOrdersDataFetcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DataFetcher;
 
 use Exception;
@@ -14,15 +16,8 @@ use Sylius\Component\Core\OrderPaymentStates;
  */
 class NumberOfOrdersDataFetcher extends TimePeriodDataFetcher
 {
-    /**
-     * @var string
-     */
-    private $orderClass;
+    private string $orderClass;
 
-    /**
-     * @param QueryFilterInterface $queryFilter
-     * @param string $orderClass
-     */
     public function __construct(
         QueryFilterInterface $queryFilter,
         string $orderClass
@@ -33,7 +28,6 @@ class NumberOfOrdersDataFetcher extends TimePeriodDataFetcher
     }
 
     /**
-     * {@inheritdoc}
      * @throws Exception
      */
     protected function setupQueryFilter(array $configuration = []): void
@@ -70,9 +64,6 @@ class NumberOfOrdersDataFetcher extends TimePeriodDataFetcher
         $this->queryFilter->addUserPostcode($configuration, 'billing');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getType(): string
     {
         return NumberOfOrdersType::class;

--- a/src/DataFetcher/SalesTotalDataFetcher.php
+++ b/src/DataFetcher/SalesTotalDataFetcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DataFetcher;
 
 use Exception;
@@ -14,15 +16,8 @@ use Sylius\Component\Core\OrderPaymentStates;
  */
 class SalesTotalDataFetcher extends TimePeriodDataFetcher
 {
-    /**
-     * @var string
-     */
-    private $orderClass;
+    private string $orderClass;
 
-    /**
-     * @param QueryFilterInterface $queryFilter
-     * @param string $orderClass
-     */
     public function __construct(
         QueryFilterInterface $queryFilter,
         string $orderClass
@@ -33,7 +28,6 @@ class SalesTotalDataFetcher extends TimePeriodDataFetcher
     }
 
     /**
-     * {@inheritdoc}
      * @throws Exception
      */
     protected function setupQueryFilter(array $configuration = []): void
@@ -70,9 +64,6 @@ class SalesTotalDataFetcher extends TimePeriodDataFetcher
         $this->queryFilter->addUserPostcode($configuration, 'billing');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getType(): string
     {
         return SalesTotalType::class;

--- a/src/DataFetcher/TimePeriodDataFetcher.php
+++ b/src/DataFetcher/TimePeriodDataFetcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DataFetcher;
 
 use DateInterval;
@@ -19,10 +21,7 @@ abstract class TimePeriodDataFetcher extends BaseDataFetcher
     const PERIOD_MONTH = 'month';
     const PERIOD_YEAR = 'year';
 
-    /**
-     * @return array
-     */
-    public static function getPeriodChoices()
+    public static function getPeriodChoices(): array
     {
         return [
             'odiseo_sylius_report.ui.daily' => self::PERIOD_DAY,
@@ -32,14 +31,13 @@ abstract class TimePeriodDataFetcher extends BaseDataFetcher
     }
 
     /**
-     * {@inheritdoc}
      * @throws Exception
      */
     public function fetch(array $configuration): Data
     {
         $data = new Data();
 
-        /** @var DateTime $endDate */
+        /** @var DateTime|null $endDate */
         $endDate = isset($configuration['timePeriod']['end']) ? $configuration['timePeriod']['end'] : null;
 
         //There is added 23 hours 59 minutes 59 seconds to the end date to provide records for whole end date
@@ -61,14 +59,14 @@ abstract class TimePeriodDataFetcher extends BaseDataFetcher
 
         $rawData = $this->getData($configuration);
 
-        if (empty($rawData)) {
+        if ([] === $rawData) {
             return $data;
         }
 
         $labelsAux = array_keys($rawData[0]);
         $labels = [];
         foreach ($labelsAux as $label) {
-            if (!in_array($label, ['MonthDate', 'YearDate', 'DateDate'])) {
+            if (!in_array($label, ['MonthDate', 'YearDate', 'DateDate'], true)) {
                 $labels[] = $label;
             }
         }
@@ -96,7 +94,7 @@ abstract class TimePeriodDataFetcher extends BaseDataFetcher
 
         $labels = [];
         foreach ($labelsAux as $label) {
-            if (!in_array($label, ['MonthDate', 'YearDate', 'DateDate'])) {
+            if (!in_array($label, ['MonthDate', 'YearDate', 'DateDate'], true)) {
                 $labels[] = preg_replace('/(?!^)[A-Z]{2,}(?=[A-Z][a-z])|[A-Z][a-z]/', ' $0', (string)$label);
             }
         }
@@ -105,20 +103,13 @@ abstract class TimePeriodDataFetcher extends BaseDataFetcher
         return $data;
     }
 
-    /**
-     * @param array  $configuration
-     * @param string $interval
-     * @param string $periodFormat
-     * @param string $presentationFormat
-     * @param array  $groupBy
-     */
     protected function setExtraConfiguration(
         array &$configuration,
-        $interval,
-        $periodFormat,
-        $presentationFormat,
+        string $interval,
+        string $periodFormat,
+        string $presentationFormat,
         array $groupBy
-    ) {
+    ): void {
         $configuration['timePeriod']['interval'] = $interval;
         $configuration['timePeriod']['periodFormat'] = $periodFormat;
         $configuration['timePeriod']['presentationFormat'] = $presentationFormat;
@@ -126,13 +117,7 @@ abstract class TimePeriodDataFetcher extends BaseDataFetcher
         $configuration['empty_records'] = false;
     }
 
-    /**
-     * @param array $fetched
-     * @param array $configuration
-     *
-     * @return array
-     */
-    private function fillEmptyRecords(array $fetched, array $configuration)
+    private function fillEmptyRecords(array $fetched, array $configuration): array
     {
         /** @var DateTime $startDate */
         $startDate = $configuration['start'];

--- a/src/DataFetcher/UserRegistrationDataFetcher.php
+++ b/src/DataFetcher/UserRegistrationDataFetcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DataFetcher;
 
 use Exception;
@@ -12,15 +14,8 @@ use Odiseo\SyliusReportPlugin\Form\Type\DataFetcher\UserRegistrationType;
  */
 class UserRegistrationDataFetcher extends TimePeriodDataFetcher
 {
-    /**
-     * @var string
-     */
-    private $orderClass;
+    private string $orderClass;
 
-    /**
-     * @param QueryFilterInterface $queryFilter
-     * @param string $orderClass
-     */
     public function __construct(
         QueryFilterInterface $queryFilter,
         string $orderClass
@@ -31,7 +26,6 @@ class UserRegistrationDataFetcher extends TimePeriodDataFetcher
     }
 
     /**
-     * @inheritdoc
      * @throws Exception
      */
     protected function setupQueryFilter(array $configuration = []): void
@@ -49,9 +43,6 @@ class UserRegistrationDataFetcher extends TimePeriodDataFetcher
         $this->queryFilter->addUserGender($configuration);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getType(): string
     {
         return UserRegistrationType::class;

--- a/src/DependencyInjection/Compiler/RegisterDataFetchersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterDataFetchersPass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DependencyInjection\Compiler;
 
 use InvalidArgumentException;
@@ -16,10 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterDataFetchersPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('odiseo_sylius_report.registry.data_fetcher')) {
             return;

--- a/src/DependencyInjection/Compiler/RegisterRenderersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterRenderersPass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\DependencyInjection\Compiler;
 
 use InvalidArgumentException;
@@ -16,10 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterRenderersPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('odiseo_sylius_report.registry.renderer')) {
             return;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,9 +26,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 final class Configuration implements ConfigurationInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('odiseo_sylius_report_plugin');
@@ -48,10 +45,7 @@ final class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    /**
-     * @param ArrayNodeDefinition $node
-     */
-    private function addResourcesSection(ArrayNodeDefinition $node)
+    private function addResourcesSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()

--- a/src/Filter/QueryFilter.php
+++ b/src/Filter/QueryFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Filter;
 
 use DateTime;
@@ -13,21 +15,16 @@ use Sylius\Component\Core\Model\ProductInterface;
 
 /**
  * @author Odiseo Team <team@odiseo.com.ar>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 class QueryFilter implements QueryFilterInterface
 {
-    /** @var EntityManager */
-    protected $em;
+    protected EntityManager $em;
 
-    /** @var QueryBuilder */
-    protected $qb;
+    protected QueryBuilder $qb;
 
-    /** @var array */
-    protected $joins = [];
+    protected array $joins = [];
 
-    /**
-     * @param EntityManager $entityManager
-     */
     public function __construct(EntityManager $entityManager)
     {
         $this->em = $entityManager;
@@ -35,37 +32,27 @@ class QueryFilter implements QueryFilterInterface
         $this->qb = $this->em->createQueryBuilder();
     }
 
-    /**
-     * @return QueryBuilder
-     */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): QueryBuilder
     {
         return $this->qb;
     }
 
-    /**
-     * @return EntityManager
-     */
-    public function getEntityManager()
+    public function getEntityManager(): EntityManager
     {
         return $this->em;
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->qb = $this->em->createQueryBuilder();
         $this->joins = [];
     }
 
-    /**
-     * @param QueryBuilder $qb
-     * @param array $configuration
-     * @param string $dateField
-     *
-     * @return array
-     */
-    protected function getGroupByParts(QueryBuilder $qb, array $configuration = [], $dateField = 'checkoutCompletedAt')
-    {
+    protected function getGroupByParts(
+        QueryBuilder $qb,
+        array $configuration = [],
+        string $dateField = 'checkoutCompletedAt'
+    ): array {
         if (false === strpos($dateField, '.')) {
             $rootAlias = $qb->getRootAliases()[0];
             $dateF = $rootAlias.'.'.$dateField;
@@ -89,13 +76,7 @@ class QueryFilter implements QueryFilterInterface
         return [$selectPeriod, $selectGroupBy];
     }
 
-    /**
-     * @param string $join
-     * @param string $alias
-     *
-     * @return string
-     */
-    public function addLeftJoin($join, $alias): string
+    public function addLeftJoin(string $join, string $alias): string
     {
         if (!isset($this->joins[$join])) {
             $this->joins[$join] = $alias;
@@ -106,14 +87,11 @@ class QueryFilter implements QueryFilterInterface
         return $this->joins[$join];
     }
 
-    /**
-     * @param array $configuration
-     * @param string $dateField
-     * @param string $rootAlias
-     * @throws Exception
-     */
-    public function addTimePeriod(array $configuration = [], $dateField = 'checkoutCompletedAt', $rootAlias = null): void
-    {
+    public function addTimePeriod(
+        array $configuration = [],
+        string $dateField = 'checkoutCompletedAt',
+        ?string $rootAlias = null
+    ): void {
         if (false === strpos($dateField, '.')) {
             if (!$rootAlias) {
                 $rootAlias = $this->qb->getRootAliases()[0];
@@ -152,13 +130,11 @@ class QueryFilter implements QueryFilterInterface
         }
     }
 
-    /**
-     * @param array $configuration
-     * @param string $field
-     * @param string $rootAlias
-     */
-    public function addChannel(array $configuration = [], $field = null, $rootAlias = null): void
-    {
+    public function addChannel(
+        array $configuration = [],
+        ?string $field = null,
+        ?string $rootAlias = null
+    ): void {
         if (isset($configuration['channel']) && count($configuration['channel']) > 0) {
             $storeIds = [];
 
@@ -186,11 +162,7 @@ class QueryFilter implements QueryFilterInterface
         }
     }
 
-    /**
-     * @param array $configuration
-     * @param string $rootAlias
-     */
-    public function addUserGender(array $configuration = [], $rootAlias = null): void
+    public function addUserGender(array $configuration = [], ?string $rootAlias = null): void
     {
         if (isset($configuration['userGender']) && count($configuration['userGender']) > 0) {
             $cAlias = $rootAlias;
@@ -208,13 +180,11 @@ class QueryFilter implements QueryFilterInterface
         }
     }
 
-    /**
-     * @param array $configuration
-     * @param string $addressType
-     * @param string $rootAlias
-     */
-    public function addUserCountry(array $configuration = [], string $addressType = 'shipping', $rootAlias = null): void
-    {
+    public function addUserCountry(
+        array $configuration = [],
+        string $addressType = 'shipping',
+        ?string $rootAlias = null
+    ): void {
         $type = 'user'.ucfirst($addressType).'Country';
 
         if (isset($configuration[$type]) && count($configuration[$type]) > 0) {
@@ -235,13 +205,11 @@ class QueryFilter implements QueryFilterInterface
         }
     }
 
-    /**
-     * @param array $configuration
-     * @param string $addressType
-     * @param string $rootAlias
-     */
-    public function addUserProvince(array $configuration = [], string $addressType = 'shipping', $rootAlias = null): void
-    {
+    public function addUserProvince(
+        array $configuration = [],
+        string $addressType = 'shipping',
+        ?string $rootAlias = null
+    ): void {
         $type = 'user'.ucfirst($addressType).'Province';
 
         if (isset($configuration[$type]) && count($configuration[$type]) > 0) {
@@ -269,13 +237,11 @@ class QueryFilter implements QueryFilterInterface
         }
     }
 
-    /**
-     * @param array $configuration
-     * @param string $addressType
-     * @param string $rootAlias
-     */
-    public function addUserCity(array $configuration = [], string $addressType = 'shipping', $rootAlias = null): void
-    {
+    public function addUserCity(
+        array $configuration = [],
+        string $addressType = 'shipping',
+        ?string $rootAlias = null
+    ): void {
         $type = 'user'.ucfirst($addressType).'City';
 
         if (isset($configuration[$type]) && count($configuration[$type]) > 0) {
@@ -300,13 +266,11 @@ class QueryFilter implements QueryFilterInterface
         }
     }
 
-    /**
-     * @param array $configuration
-     * @param string $addressType
-     * @param string $rootAlias
-     */
-    public function addUserPostcode(array $configuration = [], string $addressType = 'shipping', $rootAlias = null): void
-    {
+    public function addUserPostcode(
+        array $configuration = [],
+        string $addressType = 'shipping',
+        ?string $rootAlias = null
+    ): void {
         $type = 'user'.ucfirst($addressType).'Postcode';
 
         if (isset($configuration[$type]) && count($configuration[$type]) > 0) {
@@ -331,10 +295,6 @@ class QueryFilter implements QueryFilterInterface
         }
     }
 
-    /**
-     * @param array $configuration
-     * @param string $field
-     */
     public function addProduct(array $configuration = [], string $field = 'p.id'): void
     {
         if (isset($configuration['product']) && count($configuration['product']) > 0) {
@@ -348,10 +308,6 @@ class QueryFilter implements QueryFilterInterface
         }
     }
 
-    /**
-     * @param array $configuration
-     * @param string $field
-     */
     public function addProductCategory(array $configuration = [], string $field = 'pt.taxon'): void
     {
         if (isset($configuration['productCategory']) && count($configuration['productCategory']) > 0) {
@@ -361,12 +317,7 @@ class QueryFilter implements QueryFilterInterface
         }
     }
 
-    /**
-     * @param string $rootEntityClassname
-     *
-     * @return bool
-     */
-    protected function hasRootEntity($rootEntityClassname): bool
+    protected function hasRootEntity(string $rootEntityClassname): bool
     {
         return in_array($rootEntityClassname, $this->qb->getRootEntities());
     }

--- a/src/Filter/QueryFilterInterface.php
+++ b/src/Filter/QueryFilterInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Filter;
 
 use Doctrine\ORM\EntityManager;
@@ -8,87 +10,69 @@ use Exception;
 
 /**
  * @author Odiseo Team <team@odiseo.com.ar>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 interface QueryFilterInterface
 {
-    /**
-     * @return QueryBuilder
-     */
-    public function getQueryBuilder();
+    public function getQueryBuilder(): QueryBuilder;
+
+    public function getEntityManager(): EntityManager;
+
+    public function reset(): void;
+
+    public function addLeftJoin(string $join, string $alias): string;
 
     /**
-     * @return EntityManager
-     */
-    public function getEntityManager();
-
-    public function reset();
-
-    /**
-     * @param string $join
-     * @param string $alias
-     *
-     * @return string
-     */
-    public function addLeftJoin($join, $alias): string;
-
-    /**
-     * @param array $configuration
-     * @param string $dateField
-     * @param string $rootAlias
      * @throws Exception
      */
-    public function addTimePeriod(array $configuration = [], $dateField = 'checkoutCompletedAt', $rootAlias = null): void;
+    public function addTimePeriod(
+        array $configuration = [],
+        string $dateField = 'checkoutCompletedAt',
+        ?string $rootAlias = null
+    ): void;
 
-    /**
-     * @param array $configuration
-     * @param string $field
-     * @param string $rootAlias
-     */
-    public function addChannel(array $configuration = [], $field = null, $rootAlias = null): void;
+    public function addChannel(
+        array $configuration = [],
+        ?string $field = null,
+        ?string $rootAlias = null
+    ): void;
 
-    /**
-     * @param array $configuration
-     * @param string $rootAlias
-     */
-    public function addUserGender(array $configuration = [], $rootAlias = null): void;
+    public function addUserGender(
+        array $configuration = [],
+        ?string $rootAlias = null
+    ): void;
 
-    /**
-     * @param array $configuration
-     * @param string $addressType
-     * @param string $rootAlias
-     */
-    public function addUserCountry(array $configuration = [], string $addressType = 'shipping', $rootAlias = null): void;
+    public function addUserCountry(
+        array $configuration = [],
+        string $addressType = 'shipping',
+        ?string $rootAlias = null
+    ): void;
 
-    /**
-     * @param array $configuration
-     * @param string $addressType
-     * @param string $rootAlias
-     */
-    public function addUserProvince(array $configuration = [], string $addressType = 'shipping', $rootAlias = null): void;
+    public function addUserProvince(
+        array $configuration = [],
+        string $addressType = 'shipping',
+        ?string $rootAlias = null
+    ): void;
 
-    /**
-     * @param array $configuration
-     * @param string $addressType
-     * @param string $rootAlias
-     */
-    public function addUserCity(array $configuration = [], string $addressType = 'shipping', $rootAlias = null): void;
+    public function addUserCity(
+        array $configuration = [],
+        string $addressType = 'shipping',
+        ?string $rootAlias = null
+    ): void;
 
-    /**
-     * @param array $configuration
-     * @param string $addressType
-     * @param string $rootAlias
-     */
-    public function addUserPostcode(array $configuration = [], string $addressType = 'shipping', $rootAlias = null): void;
+    public function addUserPostcode(
+        array $configuration = [],
+        string $addressType = 'shipping',
+        ?string $rootAlias = null
+    ): void;
 
-    /**
-     * @param array $configuration
-     * @param string $field
-     */
-    public function addProduct(array $configuration = [], string $field = 'p.id'): void;
+    public function addProduct(
+        array $configuration = [],
+        string $field = 'p.id'
+    ): void;
 
-    /**
-     * @param array $configuration
-     * @param string $field
-     */
-    public function addProductCategory(array $configuration = [], string $field = 'pt.taxon'): void;
+    public function addProductCategory(
+        array $configuration = [],
+        string $field = 'pt.taxon'
+    ): void;
 }

--- a/src/Form/Builder/QueryFilterFormBuilder.php
+++ b/src/Form/Builder/QueryFilterFormBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Builder;
 
 use Odiseo\SyliusReportPlugin\Form\Type\AddressAutocompleteChoiceType;
@@ -21,20 +23,15 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
 {
-    /** @var RepositoryInterface */
-    protected $addressRepository;
+    protected RepositoryInterface $addressRepository;
 
-    /** @var TaxonRepositoryInterface */
-    protected $taxonRepository;
+    protected TaxonRepositoryInterface $taxonRepository;
 
-    /** @var ProductRepositoryInterface */
-    protected $productRepository;
+    protected ProductRepositoryInterface $productRepository;
 
-    /** @var ChannelRepositoryInterface */
-    protected $channelRepository;
+    protected ChannelRepositoryInterface $channelRepository;
 
-    /** @var UrlGeneratorInterface */
-    protected $generator;
+    protected UrlGeneratorInterface $generator;
 
     public function __construct(
         RepositoryInterface $addressRepository,
@@ -50,9 +47,6 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         $this->generator = $generator;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function addUserGender(FormBuilderInterface &$builder): void
     {
         $builder
@@ -69,10 +63,7 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         ;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function addUserCountry(FormBuilderInterface &$builder, $addressType = 'shipping'): void
+    public function addUserCountry(FormBuilderInterface &$builder, string $addressType = 'shipping'): void
     {
         $builder
             ->add('user'.ucfirst($addressType).'Country', CountryType::class, [
@@ -86,10 +77,7 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         ;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function addUserCity(FormBuilderInterface $builder, $addressType = 'shipping'): void
+    public function addUserCity(FormBuilderInterface $builder, string $addressType = 'shipping'): void
     {
         $builder
             ->add('user'.ucfirst($addressType).'City', AddressAutocompleteChoiceType::class, [
@@ -102,10 +90,7 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         ;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function addUserProvince(FormBuilderInterface $builder, $addressType = 'shipping'): void
+    public function addUserProvince(FormBuilderInterface $builder, string $addressType = 'shipping'): void
     {
         $builder
             ->add('user'.ucfirst($addressType).'Province', AddressAutocompleteChoiceType::class, [
@@ -118,10 +103,7 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         ;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function addUserPostcode(FormBuilderInterface $builder, $addressType = 'shipping'): void
+    public function addUserPostcode(FormBuilderInterface $builder, string $addressType = 'shipping'): void
     {
         $builder
             ->add('user'.ucfirst($addressType).'Postcode', AddressAutocompleteChoiceType::class, [
@@ -134,9 +116,6 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         ;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function addTimePeriod(FormBuilderInterface $builder): void
     {
         $builder
@@ -144,9 +123,6 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         ;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function addChannel(FormBuilderInterface $builder): void
     {
         $builder
@@ -162,9 +138,6 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         ;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function addProduct(FormBuilderInterface $builder): void
     {
         $builder
@@ -178,9 +151,6 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         ;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function addProductCategory(FormBuilderInterface $builder): void
     {
         $builder
@@ -196,9 +166,6 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         ;
     }
 
-    /**
-     * @return array
-     */
     protected function buildChannelsChoices(): array
     {
         $choices = [];
@@ -214,9 +181,6 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         return $choices;
     }
 
-    /**
-     * @return array
-     */
     protected function buildCategoriesChoices(): array
     {
         $choices = [];
@@ -230,11 +194,6 @@ class QueryFilterFormBuilder implements QueryFilterFormBuilderInterface
         return $choices;
     }
 
-    /**
-     * @param array $choices
-     * @param TaxonInterface $category
-     * @return array
-     */
     protected function addCategoryToChoices(array $choices, TaxonInterface $category): array
     {
         $choices[$category->getName()] = $category->getId();

--- a/src/Form/Builder/QueryFilterFormBuilderInterface.php
+++ b/src/Form/Builder/QueryFilterFormBuilderInterface.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Odiseo\SyliusReportPlugin\Form\Builder;
+declare(strict_types=1);
 
+namespace Odiseo\SyliusReportPlugin\Form\Builder;
 
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -10,52 +11,21 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 interface QueryFilterFormBuilderInterface
 {
-    /**
-     * @param FormBuilderInterface $builder
-     */
     public function addUserGender(FormBuilderInterface &$builder): void;
 
-    /**
-     * @param FormBuilderInterface $builder
-     * @param string $addressType
-     */
-    public function addUserCountry(FormBuilderInterface &$builder, $addressType = 'shipping'): void;
+    public function addUserCountry(FormBuilderInterface &$builder, string $addressType = 'shipping'): void;
 
-    /**
-     * @param FormBuilderInterface $builder
-     * @param string $addressType
-     */
-    public function addUserCity(FormBuilderInterface $builder, $addressType = 'shipping'): void;
+    public function addUserCity(FormBuilderInterface $builder, string $addressType = 'shipping'): void;
 
-    /**
-     * @param FormBuilderInterface $builder
-     * @param string $addressType
-     */
-    public function addUserProvince(FormBuilderInterface $builder, $addressType = 'shipping'): void;
+    public function addUserProvince(FormBuilderInterface $builder, string $addressType = 'shipping'): void;
 
-    /**
-     * @param FormBuilderInterface $builder
-     * @param string $addressType
-     */
-    public function addUserPostcode(FormBuilderInterface $builder, $addressType = 'shipping'): void;
+    public function addUserPostcode(FormBuilderInterface $builder, string $addressType = 'shipping'): void;
 
-    /**
-     * @param FormBuilderInterface $builder
-     */
     public function addTimePeriod(FormBuilderInterface $builder): void;
 
-    /**
-     * @param FormBuilderInterface $builder
-     */
     public function addChannel(FormBuilderInterface $builder): void;
 
-    /**
-     * @param FormBuilderInterface $builder
-     */
     public function addProduct(FormBuilderInterface $builder): void;
 
-    /**
-     * @param FormBuilderInterface $builder
-     */
     public function addProductCategory(FormBuilderInterface $builder): void;
 }

--- a/src/Form/EventListener/BuildReportDataFetcherFormSubscriber.php
+++ b/src/Form/EventListener/BuildReportDataFetcherFormSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\EventListener;
 
 use InvalidArgumentException;
@@ -19,18 +21,13 @@ use Symfony\Component\Form\FormInterface;
  *
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  * @author Diego D'amico <diego@odiseo.com.ar>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 class BuildReportDataFetcherFormSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var ServiceRegistryInterface
-     */
-    private $dataFetcherRegistry;
+    private ServiceRegistryInterface $dataFetcherRegistry;
 
-    /**
-     * @var FormFactoryInterface
-     */
-    private $factory;
+    private FormFactoryInterface $factory;
 
     public function __construct(ServiceRegistryInterface $dataFetcherRegistry, FormFactoryInterface $factory)
     {
@@ -38,10 +35,7 @@ class BuildReportDataFetcherFormSubscriber implements EventSubscriberInterface
         $this->factory = $factory;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::PRE_SET_DATA => 'preSetData',
@@ -49,10 +43,7 @@ class BuildReportDataFetcherFormSubscriber implements EventSubscriberInterface
         ];
     }
 
-    /**
-     * @param FormEvent $event
-     */
-    public function preSetData(FormEvent $event)
+    public function preSetData(FormEvent $event): void
     {
         $report = $event->getData();
 
@@ -67,10 +58,7 @@ class BuildReportDataFetcherFormSubscriber implements EventSubscriberInterface
         $this->addConfigurationFields($event->getForm(), $report->getDataFetcher(), $report->getDataFetcherConfiguration());
     }
 
-    /**
-     * @param FormEvent $event
-     */
-    public function preBind(FormEvent $event)
+    public function preBind(FormEvent $event): void
     {
         $data = $event->getData();
 
@@ -81,14 +69,7 @@ class BuildReportDataFetcherFormSubscriber implements EventSubscriberInterface
         $this->addConfigurationFields($event->getForm(), $data['dataFetcher']);
     }
 
-    /**
-     * Add configuration fields to the form.
-     *
-     * @param FormInterface $form
-     * @param string        $dataFetcherType
-     * @param array         $config
-     */
-    protected function addConfigurationFields(FormInterface $form, $dataFetcherType, array $config = [])
+    protected function addConfigurationFields(FormInterface $form, string $dataFetcherType, array $config = []): void
     {
         /** @var DataFetcherInterface $dataFetcher */
         $dataFetcher = $this->dataFetcherRegistry->get($dataFetcherType);

--- a/src/Form/EventListener/BuildReportRendererFormSubscriber.php
+++ b/src/Form/EventListener/BuildReportRendererFormSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\EventListener;
 
 use InvalidArgumentException;
@@ -19,18 +21,13 @@ use Symfony\Component\Form\FormInterface;
  *
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  * @author Diego D'amico <diego@odiseo.com.ar>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 class BuildReportRendererFormSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var ServiceRegistryInterface
-     */
-    private $rendererRegistry;
+    private ServiceRegistryInterface $rendererRegistry;
 
-    /**
-     * @var FormFactoryInterface
-     */
-    private $factory;
+    private FormFactoryInterface $factory;
 
     public function __construct(ServiceRegistryInterface $rendererRegistry, FormFactoryInterface $factory)
     {
@@ -38,10 +35,7 @@ class BuildReportRendererFormSubscriber implements EventSubscriberInterface
         $this->factory = $factory;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::PRE_SET_DATA => 'preSetData',
@@ -49,10 +43,7 @@ class BuildReportRendererFormSubscriber implements EventSubscriberInterface
         ];
     }
 
-    /**
-     * @param FormEvent $event
-     */
-    public function preSetData(FormEvent $event)
+    public function preSetData(FormEvent $event): void
     {
         $report = $event->getData();
 
@@ -67,10 +58,7 @@ class BuildReportRendererFormSubscriber implements EventSubscriberInterface
         $this->addConfigurationFields($event->getForm(), $report->getRenderer(), $report->getRendererConfiguration());
     }
 
-    /**
-     * @param FormEvent $event
-     */
-    public function preBind(FormEvent $event)
+    public function preBind(FormEvent $event): void
     {
         $data = $event->getData();
 
@@ -81,14 +69,7 @@ class BuildReportRendererFormSubscriber implements EventSubscriberInterface
         $this->addConfigurationFields($event->getForm(), $data['renderer']);
     }
 
-    /**
-     * Add configuration fields to the form.
-     *
-     * @param FormInterface $form
-     * @param string        $rendererType
-     * @param array         $data
-     */
-    public function addConfigurationFields(FormInterface $form, $rendererType, array $data = [])
+    public function addConfigurationFields(FormInterface $form, string $rendererType, array $data = []): void
     {
         /** @var RendererInterface $renderer */
         $renderer = $this->rendererRegistry->get($rendererType);

--- a/src/Form/Type/AddressAutocompleteChoiceType.php
+++ b/src/Form/Type/AddressAutocompleteChoiceType.php
@@ -15,9 +15,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class AddressAutocompleteChoiceType extends AbstractType
 {
-    /**
-     * @inheritDoc
-     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
@@ -31,9 +28,6 @@ final class AddressAutocompleteChoiceType extends AbstractType
         ;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['remote_criteria_type'] = 'contains';
@@ -41,17 +35,11 @@ final class AddressAutocompleteChoiceType extends AbstractType
         $view->vars['remote_url'] = $view->vars['load_edit_url'] = $options['remote_url'];
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getBlockPrefix(): string
     {
         return 'odiseo_address_autocomplete_choice';
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getParent(): string
     {
         return ResourceAutocompleteChoiceType::class;

--- a/src/Form/Type/DataFetcher/BaseDataFetcherType.php
+++ b/src/Form/Type/DataFetcher/BaseDataFetcherType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type\DataFetcher;
 
 use Odiseo\SyliusReportPlugin\Form\Builder\QueryFilterFormBuilderInterface;
@@ -10,10 +12,7 @@ use Symfony\Component\Form\AbstractType;
  */
 abstract class BaseDataFetcherType extends AbstractType
 {
-    /**
-     * @var QueryFilterFormBuilderInterface
-     */
-    protected $queryFilterFormBuilder;
+    protected QueryFilterFormBuilderInterface $queryFilterFormBuilder;
 
     public function __construct(QueryFilterFormBuilderInterface $queryFilterFormBuilder)
     {

--- a/src/Form/Type/DataFetcher/DataFetcherChoiceType.php
+++ b/src/Form/Type/DataFetcher/DataFetcherChoiceType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type\DataFetcher;
 
 use Symfony\Component\Form\AbstractType;
@@ -12,23 +14,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class DataFetcherChoiceType extends AbstractType
 {
-    /**
-     * @var array|false
-     */
-    protected $dataFetchers;
+    protected array $dataFetchers;
 
-    /**
-     * @param array $dataFetchers
-     */
-    public function __construct($dataFetchers)
+    public function __construct(array $dataFetchers)
     {
-        $this->dataFetchers = array_combine(array_values($dataFetchers), array_keys($dataFetchers));
+        $this->dataFetchers = array_combine(array_values($dataFetchers), array_keys($dataFetchers)) ?: [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -37,18 +30,12 @@ class DataFetcherChoiceType extends AbstractType
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'odiseo_sylius_report_data_fetcher_choice';
     }

--- a/src/Form/Type/DataFetcher/NumberOfOrdersType.php
+++ b/src/Form/Type/DataFetcher/NumberOfOrdersType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type\DataFetcher;
 
 use Symfony\Component\Form\FormBuilderInterface;
@@ -10,10 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class NumberOfOrdersType extends TimePeriodChannelType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 
@@ -28,10 +27,7 @@ class NumberOfOrdersType extends TimePeriodChannelType
         $this->queryFilterFormBuilder->addUserPostcode($builder, 'billing');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'odiseo_sylius_report_data_fetcher_number_of_orders';
     }

--- a/src/Form/Type/DataFetcher/SalesTotalType.php
+++ b/src/Form/Type/DataFetcher/SalesTotalType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type\DataFetcher;
 
 use Symfony\Component\Form\FormBuilderInterface;
@@ -10,10 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class SalesTotalType extends TimePeriodChannelType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 
@@ -28,10 +27,7 @@ class SalesTotalType extends TimePeriodChannelType
         $this->queryFilterFormBuilder->addUserPostcode($builder, 'billing');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'odiseo_sylius_report_data_fetcher_sales_total';
     }

--- a/src/Form/Type/DataFetcher/TimePeriodChannelType.php
+++ b/src/Form/Type/DataFetcher/TimePeriodChannelType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type\DataFetcher;
 
 use Symfony\Component\Form\FormBuilderInterface;
@@ -9,10 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class TimePeriodChannelType extends BaseDataFetcherType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 

--- a/src/Form/Type/DataFetcher/TimePeriodType.php
+++ b/src/Form/Type/DataFetcher/TimePeriodType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type\DataFetcher;
 
 use DateTime;
@@ -15,10 +17,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 final class TimePeriodType extends AbstractType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('start', DateType::class, [
@@ -42,10 +41,7 @@ final class TimePeriodType extends AbstractType
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'odiseo_sylius_report_data_fetcher_time_period';
     }

--- a/src/Form/Type/DataFetcher/UserRegistrationType.php
+++ b/src/Form/Type/DataFetcher/UserRegistrationType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type\DataFetcher;
 
 use Symfony\Component\Form\FormBuilderInterface;
@@ -10,20 +12,14 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class UserRegistrationType extends TimePeriodChannelType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 
         $this->queryFilterFormBuilder->addUserGender($builder);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'odiseo_sylius_report_data_fetcher_user_registration';
     }

--- a/src/Form/Type/ProductAutocompleteChoiceType.php
+++ b/src/Form/Type/ProductAutocompleteChoiceType.php
@@ -15,9 +15,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class ProductAutocompleteChoiceType extends AbstractType
 {
-    /**
-     * @inheritDoc
-     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
@@ -31,9 +28,6 @@ final class ProductAutocompleteChoiceType extends AbstractType
         ;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['remote_criteria_type'] = 'contains';
@@ -41,17 +35,11 @@ final class ProductAutocompleteChoiceType extends AbstractType
         $view->vars['remote_url'] = $view->vars['load_edit_url'] = $options['remote_url'];
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getBlockPrefix(): string
     {
         return 'odiseo_product_autocomplete_choice';
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getParent(): string
     {
         return ResourceAutocompleteChoiceType::class;

--- a/src/Form/Type/Renderer/ChartConfigurationType.php
+++ b/src/Form/Type/Renderer/ChartConfigurationType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type\Renderer;
 
 use Odiseo\SyliusReportPlugin\Renderer\ChartRenderer;
@@ -15,10 +17,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class ChartConfigurationType extends AbstractType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('type', ChoiceType::class, [
@@ -34,10 +33,7 @@ class ChartConfigurationType extends AbstractType
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'odiseo_sylius_report_renderer_chart';
     }

--- a/src/Form/Type/Renderer/RendererChoiceType.php
+++ b/src/Form/Type/Renderer/RendererChoiceType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type\Renderer;
 
 use Symfony\Component\Form\AbstractType;
@@ -11,23 +13,18 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  * @author Diego D'amico <diego@odiseo.com.ar>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 class RendererChoiceType extends AbstractType
 {
-    /**
-     * @var array|false
-     */
-    protected $renderers;
+    protected array $renderers;
 
     public function __construct(array $renderers)
     {
-        $this->renderers = array_combine(array_values($renderers), array_keys($renderers));
+        $this->renderers = array_combine(array_values($renderers), array_keys($renderers)) ?: [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -36,18 +33,12 @@ class RendererChoiceType extends AbstractType
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'odiseo_sylius_report_renderer_choice';
     }

--- a/src/Form/Type/Renderer/TableConfigurationType.php
+++ b/src/Form/Type/Renderer/TableConfigurationType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type\Renderer;
 
 use Symfony\Component\Form\AbstractType;
@@ -14,10 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class TableConfigurationType extends AbstractType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('template', ChoiceType::class, [
@@ -29,10 +28,7 @@ class TableConfigurationType extends AbstractType
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'odiseo_sylius_report_renderer_table';
     }

--- a/src/Form/Type/ReportDataFetcherConfigurationType.php
+++ b/src/Form/Type/ReportDataFetcherConfigurationType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type;
 
 use Odiseo\SyliusReportPlugin\DataFetcher\DelegatingDataFetcherInterface;
@@ -12,15 +14,9 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class ReportDataFetcherConfigurationType extends AbstractResourceType
 {
-    /**
-     * @var DelegatingDataFetcherInterface
-     */
-    protected $delegatingDataFetcher;
+    protected DelegatingDataFetcherInterface $delegatingDataFetcher;
 
-    /**
-     * @var string
-     */
-    protected $dataFetcherConfigurationTemplate;
+    protected string $dataFetcherConfigurationTemplate;
 
     public function __construct(
         string $dataClass,
@@ -33,10 +29,7 @@ class ReportDataFetcherConfigurationType extends AbstractResourceType
         $this->delegatingDataFetcher = $delegatingDataFetcher;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         /** @var ReportInterface $report */
         $report = $builder->getData();
@@ -45,10 +38,7 @@ class ReportDataFetcherConfigurationType extends AbstractResourceType
         $builder->add('dataFetcherConfiguration', $dataFetcher->getType());
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'odiseo_sylius_report';
     }

--- a/src/Form/Type/ReportType.php
+++ b/src/Form/Type/ReportType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Form\Type;
 
 use InvalidArgumentException;
@@ -25,36 +27,16 @@ use Symfony\Component\Form\FormView;
  */
 class ReportType extends AbstractResourceType
 {
-    /**
-     * @var ServiceRegistryInterface
-     */
-    protected $rendererRegistry;
+    protected ServiceRegistryInterface $rendererRegistry;
 
-    /**
-     * @var ServiceRegistryInterface
-     */
-    protected $dataFetcherRegistry;
+    protected ServiceRegistryInterface $dataFetcherRegistry;
 
-    /**
-     * @var string
-     */
-    protected $rendererConfigurationTemplate;
+    protected string $rendererConfigurationTemplate;
 
-    /**
-     * @var string
-     */
-    protected $dataFetcherConfigurationTemplate;
+    protected string $dataFetcherConfigurationTemplate;
 
-    /**
-     * @param string $dataClass FQCN
-     * @param string[] $validationGroups
-     * @param ServiceRegistryInterface $rendererRegistry
-     * @param ServiceRegistryInterface $dataFetcherRegistry
-     * @param string $rendererConfigurationTemplate
-     * @param string $dataFetcherConfigurationTemplate
-     */
     public function __construct(
-        $dataClass,
+        string $dataClass,
         array $validationGroups,
         ServiceRegistryInterface $rendererRegistry,
         ServiceRegistryInterface $dataFetcherRegistry,
@@ -69,10 +51,7 @@ class ReportType extends AbstractResourceType
         $this->dataFetcherConfigurationTemplate = $dataFetcherConfigurationTemplate;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->addEventSubscriber(new AddCodeFormSubscriber())
@@ -128,10 +107,7 @@ class ReportType extends AbstractResourceType
         $builder->setAttribute('prototypes', $prototypes);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['prototypes'] = [];
         $view->vars['rendererConfigurationTemplate'] = $this->rendererConfigurationTemplate;
@@ -145,10 +121,7 @@ class ReportType extends AbstractResourceType
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'odiseo_sylius_report';
     }

--- a/src/Menu/AdminMenuListener.php
+++ b/src/Menu/AdminMenuListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Menu;
 
 use Sylius\Bundle\UiBundle\Menu\Event\MenuBuilderEvent;
@@ -9,10 +11,7 @@ use Sylius\Bundle\UiBundle\Menu\Event\MenuBuilderEvent;
  */
 final class AdminMenuListener
 {
-    /**
-     * @param MenuBuilderEvent $event
-     */
-    public function addAdminMenuItems(MenuBuilderEvent $event)
+    public function addAdminMenuItems(MenuBuilderEvent $event): void
     {
         $menu = $event->getMenu();
 

--- a/src/Model/Report.php
+++ b/src/Model/Report.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Model;
 
 use DateTime;
@@ -22,44 +24,25 @@ class Report implements ReportInterface
      */
     protected $id;
 
-    /**
-     * @var string|null
-     */
-    protected $code;
+    protected ?string $code = null;
 
-    /**
-     * @var string
-     */
-    protected $name;
+    protected ?string $name = null;
 
-    /**
-     * @var string
-     */
-    protected $description;
+    protected ?string $description = null;
 
     /**
      * Renderer name.
-     *
-     * @var string
      */
-    protected $renderer = DefaultRenderers::TABLE;
+    protected string $renderer = DefaultRenderers::TABLE;
 
-    /**
-     * @var array
-     */
-    protected $rendererConfiguration = [];
+    protected array $rendererConfiguration = [];
 
     /**
      * Data fetcher name.
-     *
-     * @var string
      */
-    protected $dataFetcher = DefaultDataFetchers::USER_REGISTRATION;
+    protected string $dataFetcher = DefaultDataFetchers::USER_REGISTRATION;
 
-    /**
-     * @var array
-     */
-    protected $dataFetcherConfiguration = [];
+    protected array $dataFetcherConfiguration = [];
 
     public function __construct()
     {
@@ -81,114 +64,72 @@ class Report implements ReportInterface
         return $this->id;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getCode(): ?string
     {
         return $this->code;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setCode(?string $code): void
     {
         $this->code = $code;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setName($name)
+    public function setName(?string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setDescription($description)
+    public function setDescription(?string $description): void
     {
         $this->description = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getDataFetcher()
+    public function getDataFetcher(): string
     {
         return $this->dataFetcher;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setDataFetcher(string $dataFetcher)
+    public function setDataFetcher(string $dataFetcher): void
     {
         $this->dataFetcher = $dataFetcher;
     }
 
-    /**
-     * @return string
-     */
-    public function getRenderer()
+    public function getRenderer(): string
     {
         return $this->renderer;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setRenderer(string $renderer)
+    public function setRenderer(string $renderer): void
     {
         $this->renderer = $renderer;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getDataFetcherConfiguration()
+    public function getDataFetcherConfiguration(): array
     {
         return $this->dataFetcherConfiguration;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setDataFetcherConfiguration(array $dataFetcherConfiguration)
+    public function setDataFetcherConfiguration(array $dataFetcherConfiguration): void
     {
         $this->dataFetcherConfiguration = $dataFetcherConfiguration;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getRendererConfiguration()
+    public function getRendererConfiguration(): array
     {
         return $this->rendererConfiguration;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setRendererConfiguration(array $rendererConfiguration)
+    public function setRendererConfiguration(array $rendererConfiguration): void
     {
         $this->rendererConfiguration = $rendererConfiguration;
     }

--- a/src/Model/ReportInterface.php
+++ b/src/Model/ReportInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Model;
 
 use Sylius\Component\Resource\Model\CodeAwareInterface;
@@ -10,66 +12,31 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  * @author Diego D'amico <diego@odiseo.com.ar>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 interface ReportInterface extends CodeAwareInterface, ResourceInterface, TimestampableInterface
 {
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): ?string;
 
-    /**
-     * @param string $name
-     */
-    public function setName($name);
+    public function setName(?string $name): void;
 
-    /**
-     * @return string
-     */
-    public function getDescription();
+    public function getDescription(): ?string;
 
-    /**
-     * @param string $description
-     */
-    public function setDescription($description);
+    public function setDescription(?string $description): void;
 
-    /**
-     * @return string|null
-     */
-    public function getRenderer();
+    public function getRenderer(): string;
 
-    /**
-     * @param string $renderer
-     */
-    public function setRenderer(string $renderer);
+    public function setRenderer(string $renderer): void;
 
-    /**
-     * @return array
-     */
-    public function getRendererConfiguration();
+    public function getRendererConfiguration(): array;
 
-    /**
-     * @param array $rendererConfiguration
-     */
-    public function setRendererConfiguration(array $rendererConfiguration);
+    public function setRendererConfiguration(array $rendererConfiguration): void;
 
-    /**
-     * @return string|null
-     */
-    public function getDataFetcher();
+    public function getDataFetcher(): string;
 
-    /**
-     * @param string $dataFetcher
-     */
-    public function setDataFetcher(string $dataFetcher);
+    public function setDataFetcher(string $dataFetcher): void;
 
-    /**
-     * @return array
-     */
-    public function getDataFetcherConfiguration();
+    public function getDataFetcherConfiguration(): array;
 
-    /**
-     * @param array $dataFetcherConfiguration
-     */
-    public function setDataFetcherConfiguration(array $dataFetcherConfiguration);
+    public function setDataFetcherConfiguration(array $dataFetcherConfiguration): void;
 }

--- a/src/OdiseoSyliusReportPlugin.php
+++ b/src/OdiseoSyliusReportPlugin.php
@@ -34,7 +34,7 @@ final class OdiseoSyliusReportPlugin extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container) :void
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Renderer/ChartRenderer.php
+++ b/src/Renderer/ChartRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Renderer;
 
 use Odiseo\SyliusReportPlugin\DataFetcher\Data;
@@ -11,6 +13,7 @@ use Twig\Environment;
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  * @author Diego D'amico <diego@odiseo.com.ar>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 class ChartRenderer implements RendererInterface
 {
@@ -21,23 +24,14 @@ class ChartRenderer implements RendererInterface
     const PIE_CHART = 'pie';
     const DOUGHNUT_CHART = 'doughnut';
 
-    /**
-     * @var Environment
-     */
-    private $templating;
+    private Environment $templating;
 
-    /**
-     * @param Environment $templating
-     */
     public function __construct(Environment $templating)
     {
         $this->templating = $templating;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function render(ReportInterface $report, Data $data)
+    public function render(ReportInterface $report, Data $data): string
     {
         if (null !== $data->getData()) {
             $rendererData = [
@@ -59,18 +53,12 @@ class ChartRenderer implements RendererInterface
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
+    public function getType(): string
     {
         return ChartConfigurationType::class;
     }
 
-    /**
-     * @return array
-     */
-    public static function getChartTypes()
+    public static function getChartTypes(): array
     {
         return [
             'Bar chart' => self::BAR_CHART,

--- a/src/Renderer/DefaultRenderers.php
+++ b/src/Renderer/DefaultRenderers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Renderer;
 
 /**

--- a/src/Renderer/DelegatingRenderer.php
+++ b/src/Renderer/DelegatingRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Renderer;
 
 use InvalidArgumentException;
@@ -10,47 +12,31 @@ use Sylius\Component\Registry\ServiceRegistryInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  * @author Diego D'amico <diego@odiseo.com.ar>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 class DelegatingRenderer implements DelegatingRendererInterface
 {
     /**
      * Renderer registry.
-     *
-     * @var ServiceRegistryInterface
      */
-    protected $registry;
+    protected ServiceRegistryInterface $registry;
 
-    /**
-     * @param ServiceRegistryInterface $registry
-     */
     public function __construct(ServiceRegistryInterface $registry)
     {
         $this->registry = $registry;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function render(ReportInterface $report, Data $data)
+    public function render(ReportInterface $report, Data $data): string
     {
         $renderer = $this->getRenderer($report);
 
         return $renderer->render($report, $data);
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws InvalidArgumentException If the report subject does not have a renderer.
-     */
-    public function getRenderer(ReportInterface $report)
+    public function getRenderer(ReportInterface $report): RendererInterface
     {
-        if (null === $type = $report->getRenderer()) {
-            throw new InvalidArgumentException('Cannot render data for ReportInterface instance without renderer defined.');
-        }
-
         /** @var RendererInterface $renderer */
-        $renderer = $this->registry->get($type);
+        $renderer = $this->registry->get($report->getRenderer());
 
         return $renderer;
     }

--- a/src/Renderer/DelegatingRendererInterface.php
+++ b/src/Renderer/DelegatingRendererInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Renderer;
 
 use Odiseo\SyliusReportPlugin\DataFetcher\Data;
@@ -8,23 +10,11 @@ use Odiseo\SyliusReportPlugin\Model\ReportInterface;
 /**
  * @author Mateusz Zalewski <zaleslaw@.gmail.com>
  * @author Diego D'amico <diego@odiseo.com.ar>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 interface DelegatingRendererInterface
 {
-    /**
-     * @param ReportInterface $report
-     * @param Data            $data
-     *
-     * @return string
-     */
-    public function render(ReportInterface $report, Data $data);
+    public function render(ReportInterface $report, Data $data): string;
 
-    /**
-     * Return the RendererInterface of the ReportInterface given
-     *
-     * @param ReportInterface $report
-     *
-     * @return RendererInterface
-     */
-    public function getRenderer(ReportInterface $report);
+    public function getRenderer(ReportInterface $report): RendererInterface;
 }

--- a/src/Renderer/RendererInterface.php
+++ b/src/Renderer/RendererInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Renderer;
 
 use Odiseo\SyliusReportPlugin\DataFetcher\Data;
@@ -7,16 +9,7 @@ use Odiseo\SyliusReportPlugin\Model\ReportInterface;
 
 interface RendererInterface
 {
-    /**
-     * @param ReportInterface $report
-     * @param Data            $data
-     *
-     * @return string
-     */
-    public function render(ReportInterface $report, Data $data);
+    public function render(ReportInterface $report, Data $data): string;
 
-    /**
-     * @return string
-     */
-    public function getType();
+    public function getType(): string;
 }

--- a/src/Renderer/TableRenderer.php
+++ b/src/Renderer/TableRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Renderer;
 
 use Odiseo\SyliusReportPlugin\DataFetcher\Data;
@@ -11,28 +13,20 @@ use Twig\Environment;
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  * @author Diego D'amico <diego@odiseo.com.ar>
+ * @author Rimas Kudelis <rimas.kudelis@adeoweb.biz>
  */
 class TableRenderer implements RendererInterface
 {
-    /**
-     * @var Environment
-     */
-    private $templating;
+    private Environment $templating;
 
-    /**
-     * @param Environment $templating
-     */
     public function __construct(Environment $templating)
     {
         $this->templating = $templating;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function render(ReportInterface $report, Data $data)
+    public function render(ReportInterface $report, Data $data): string
     {
-        if (null !== $data->getData()) {
+        if ([] !== $data->getData()) {
             $data = [
                 'report' => $report,
                 'values' => $data->getData(),
@@ -52,10 +46,7 @@ class TableRenderer implements RendererInterface
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
+    public function getType(): string
     {
         return TableConfigurationType::class;
     }

--- a/src/Repository/ReportRepository.php
+++ b/src/Repository/ReportRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Repository;
 
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;

--- a/src/Repository/ReportRepositoryInterface.php
+++ b/src/Repository/ReportRepositoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Repository;
 
 use Sylius\Component\Resource\Repository\RepositoryInterface;

--- a/src/Response/CsvResponse.php
+++ b/src/Response/CsvResponse.php
@@ -1,50 +1,66 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Odiseo\SyliusReportPlugin\Response;
 
+use Odiseo\SyliusReportPlugin\DataFetcher\Data;
 use Symfony\Component\HttpFoundation\Response;
 
 class CsvResponse extends Response
 {
-    protected $data;
-    protected $filename = 'export.csv';
 
-    public function __construct($data = array(), $status = 200, $headers = array())
+    protected ?string $data = null;
+    protected string $filename = 'export.csv';
+
+    public function __construct(?Data $data = null, int $status = 200, array $headers = [])
     {
         parent::__construct('', $status, $headers);
         $this->setData($data);
     }
 
-    public function setData(array $data)
+    public static function create(?Data $data = null, int $status = 200, array $headers = [])
+    {
+        return new static($labels, $data, $status, $headers);
+    }
+
+    public function setData(Data $data): self
     {
         $output = fopen('php://temp', 'r+');
-        if ($output !== false) {
-            foreach ($data as $row) {
-                fputcsv($output, $row);
-            }
-            rewind($output);
-            $this->data = '';
-            while ($line = fgets($output)) {
-                $this->data .= $line;
-            }
-            $this->data .= fgets($output);
+
+        if ($output === false) {
+            throw new \RuntimeException('Could not create a buffer for CSV output.');
         }
+
+        foreach ($data->getData() as $row) {
+            fputcsv($output, $row);
+        }
+
+        rewind($output);
+        $this->data = '';
+
+        while ($line = fgets($output)) {
+            $this->data .= $line;
+        }
+
+        $this->data .= fgets($output);
 
         return $this->update();
     }
 
-    public function getFilename()
+    public function getFilename(): string
     {
         return $this->filename;
     }
 
-    public function setFilename($filename)
+    public function setFilename(string $filename): self
     {
         $this->filename = $filename;
+
         return $this->update();
     }
 
-    protected function update()
+    protected function update(): self
     {
         $this->headers->set('Content-Disposition', sprintf('attachment; filename="%s"', $this->filename));
         if (!$this->headers->has('Content-Type')) {


### PR DESCRIPTION
1. Use property, argument and return typehints everywhere. Typed properties are the reason why the required PHP version has been bumped. But 7.3 only has three months of support left anyway, so I don't think it's a big deal.
2. `Data` class now accepts any iterable as data, not just arrays. This is the change that I actually needed. To prevent the process from eating too much RAM, I want to provide an iterable object as data to `Data` instead of a simple array. I already checked, and the code seems to work well.