### PR TITLE
Fix Controller Definitions

### DIFF
--- a/src/Resources/config/routing/admin/report.yaml
+++ b/src/Resources/config/routing/admin/report.yaml
@@ -20,7 +20,7 @@ odiseo_sylius_report_plugin_admin_report_show:
     path: /reports/{id}
     methods: [GET]
     defaults:
-        _controller: odiseo_sylius_report_plugin.controller.report:renderAction
+        _controller: odiseo_sylius_report_plugin.controller.report::renderAction
         _sylius:
             template: '@OdiseoSyliusReportPlugin/show.html.twig'
     requirements:
@@ -30,7 +30,7 @@ odiseo_sylius_report_plugin_admin_report_export:
     path: /reports/{id}/export.{_format}
     methods: [GET]
     defaults:
-        _controller: odiseo_sylius_report_plugin.controller.report:exportAction
+        _controller: odiseo_sylius_report_plugin.controller.report::exportAction
         _format: csv
     requirements:
         id: '\d+'

--- a/src/Resources/views/show.html.twig
+++ b/src/Resources/views/show.html.twig
@@ -61,7 +61,7 @@
 
     {% block show_results %}
         <div id="report-results">
-            {{ render(controller('odiseo_sylius_report_plugin.controller.report:embedAction', {'report': report, 'configuration' : report.dataFetcherConfiguration})) }}
+            {{ render(controller('odiseo_sylius_report_plugin.controller.report::embedAction', {'report': report, 'configuration' : report.dataFetcherConfiguration})) }}
         </div>
     {% endblock %}
 


### PR DESCRIPTION
Add second colon to avoid errors like:

> The controller for URI "/_fragment" is not callable: Controller "odiseo_sylius_report_plugin.controller.report:embedAction" does neither exist as service nor as class.
